### PR TITLE
Fix optional AI and reduce warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ htmlescape = "0.3"
 uuid = { version = "1.4", features = ["v4"] }
 
 # Command line interface
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 
 # System interfaces
 libc = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 use log::{debug, error, info, warn};
 use std::env;
 use std::path::PathBuf;
-use std::io::{self, Write};
+use std::io::Write;
 
 /// SupaTerm - A lightweight intelligent terminal for Linux
 #[derive(Parser, Debug)]
@@ -20,9 +20,8 @@ struct Args {
     #[clap(short, long)]
     shell: Option<String>,
     
-    /// OpenAI API key (default: from environment)
-    ///#[clap(long, env = "OPENAI_API_KEY")]
-    openai_api_key: String,
+    /// OpenAI API key (optional, can also be provided via OPENAI_API_KEY env)
+    #[clap(long, env = "OPENAI_API_KEY")]
     api_key: Option<String>,
     
     /// Log level
@@ -157,7 +156,7 @@ async fn main() -> Result<()> {
                     error!("Failed to initialize fallback AI client: {}", e);
                     error!("Cannot continue without AI client");
                     // Clean up and exit
-                    terminal::cleanup();
+                    let _ = terminal::cleanup();
                     return Err(anyhow::anyhow!("Failed to initialize AI client"));
                 }
             }

--- a/src/scaffold/mod.rs
+++ b/src/scaffold/mod.rs
@@ -10,7 +10,6 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::ai::{AiClient, AiResponse, ResponseType};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 /// Template source type
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Local, Utc};
-use log::{debug, error, info, warn};
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Read, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use log::{debug, error, info, warn};
+use log::{debug, info, warn};
 use portable_pty::{
     native_pty_system, CommandBuilder, PtyPair, PtySize,
     Child as PtyChild,
@@ -13,8 +13,8 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 use vte::{Parser, Perform, Params};
 use std::path::PathBuf;
-use nix::sys::signal;
-use downcast_rs::Downcast;
+// use nix::sys::signal; // Currently unused
+// use downcast_rs::Downcast; // Currently unused
 
 
 /// Configuration for the terminal

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -3,9 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use super::*;
 
 /// Get the configuration directory
 pub fn get_config_dir() -> Result<PathBuf> {

--- a/src/utils/error.rs
+++ b/src/utils/error.rs
@@ -1,7 +1,4 @@
-use std::fmt::{self, Display, Formatter};
-use std::io;
-use std::result;
-use super::*;
+use std::fmt;
 
 /// Error kind enumeration
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -1,5 +1,4 @@
-use std::io::{self, Write};
-use crossterm::style::{Color, SetForegroundColor};
+use crossterm::style::Color;
 
 /// Text style for TUI rendering
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,5 +1,5 @@
-use std::fs::{self, create_dir_all, copy, metadata, File};
-use std::io::{self, Read, Write};
+use std::fs::{create_dir_all, copy, metadata, File};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 use std::fs::create_dir_all;
 use std::process::{Output, ExitStatus};


### PR DESCRIPTION
## Summary
- make OpenAI key optional via clap's `env` feature
- allow `AiClient` to initialize with empty key and disable AI gracefully
- clean up unused imports in utilities and modules

## Testing
- `cargo test`


